### PR TITLE
Use default meta section

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -144,10 +144,9 @@ This package is just a small wrapper around waterinfo.be to facilitate researche
 
 ## Meta
 
-This package is an experimental open-source project. All functionalities are provided as is, without any guarantee.
-
-Please note that this project is released with a [Contributor Code of Conduct](.github/CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
-
-Please [report any issues or bugs](https://github.com/ropensci/wateRinfo/issues/new).
+* We welcome [contributions](.github/CONTRIBUTING.md) including bug reports.
+* License: MIT
+* Get citation information for `wateRinfo` in R doing `citation("wateRinfo")`.
+* Please note that this project is released with a [Contributor Code of Conduct](.github/CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
 
 [![ropensci_footer](https://ropensci.org/public_images/ropensci_footer.png)](https://ropensci.org)

--- a/README.md
+++ b/README.md
@@ -1,16 +1,30 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file and knit -->
-wateRinfo <img src="man/figures/logo.png" align="right" alt="" width="120">
-===========================================================================
 
-[![Build Status](https://travis-ci.org/ropensci/wateRinfo.svg?branch=addci)](https://travis-ci.org/ropensci/wateRinfo) [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/5ia9va0jyskbvhev/branch/master?svg=true)](https://ci.appveyor.com/project/ropensci/waterinfo/branch/master) [![Coverage Status](https://coveralls.io/repos/github/ropensci/wateRinfo/badge.svg)](https://coveralls.io/r/ropensci/wateRinfo?branch=master)
+# wateRinfo <img src="man/figures/logo.png" align="right" alt="" width="120">
 
-The goal of wateRinfo is to facilitate access to the variety of environmental water-related data about Flanders (Belgium) available on [waterinfo.be](https://www.waterinfo.be/) by providing an R-interface to download time series data.
+[![Build
+Status](https://travis-ci.org/ropensci/wateRinfo.svg?branch=addci)](https://travis-ci.org/ropensci/wateRinfo)
+[![AppVeyor Build
+status](https://ci.appveyor.com/api/projects/status/5ia9va0jyskbvhev/branch/master?svg=true)](https://ci.appveyor.com/project/ropensci/waterinfo/branch/master)
+[![Coverage
+Status](https://coveralls.io/repos/github/ropensci/wateRinfo/badge.svg)](https://coveralls.io/r/ropensci/wateRinfo?branch=master)
 
-An [API](https://www.waterinfo.be/download/9f5ee0c9-dafa-46de-958b-7cac46eb8c23?dl=0) is provided by waterinfo.be to request time series data. However, this still requires the proper composition of the URL with the identification codes (`Timeseriesgroup_id` and `ts_id`) as used by the system itself. To facilitate the user in searching for stations and variables and consequently download the data of interest, this package provides some general R functions to download the `waterinfo.be` data.
+The goal of wateRinfo is to facilitate access to the variety of
+environmental water-related data about Flanders (Belgium) available on
+[waterinfo.be](https://www.waterinfo.be/) by providing an R-interface to
+download time series data.
 
-Installation
-------------
+An
+[API](https://www.waterinfo.be/download/9f5ee0c9-dafa-46de-958b-7cac46eb8c23?dl=0)
+is provided by waterinfo.be to request time series data. However, this
+still requires the proper composition of the URL with the identification
+codes (`Timeseriesgroup_id` and `ts_id`) as used by the system itself.
+To facilitate the user in searching for stations and variables and
+consequently download the data of interest, this package provides some
+general R functions to download the `waterinfo.be` data.
+
+## Installation
 
 You can install wateRinfo from GitHub with:
 
@@ -25,12 +39,15 @@ When succesfull, load it as usual:
 library(wateRinfo)
 ```
 
-Example
--------
+## Example
 
-For a number of supported variables ([documented](https://www.waterinfo.be/download/9f5ee0c9-dafa-46de-958b-7cac46eb8c23?dl=0) by VMM), the stations providing time series data for a given variable can be listed with the command `get_stations`.
+For a number of supported variables
+([documented](https://www.waterinfo.be/download/9f5ee0c9-dafa-46de-958b-7cac46eb8c23?dl=0)
+by VMM), the stations providing time series data for a given variable
+can be listed with the command `get_stations`.
 
-If you want to know the supported variables, ask for the supported variables:
+If you want to know the supported variables, ask for the supported
+variables:
 
 ``` r
 supported_variables("en")
@@ -88,7 +105,10 @@ get_stations("air_pressure")
 #> 8           hPa          VMM
 ```
 
-Each of the stations in the list for a given variable, are represented by a `ts_id`. These can be used to download the data of a given period with the command `get_timeseries_tsid`, for example Overpelt (`ts_id = 78124042`):
+Each of the stations in the list for a given variable, are represented
+by a `ts_id`. These can be used to download the data of a given period
+with the command `get_timeseries_tsid`, for example Overpelt (`ts_id
+= 78124042`):
 
 ``` r
 overpelt_pressure <- get_timeseries_tsid("78124042", 
@@ -116,7 +136,10 @@ ggplot(overpelt_pressure, aes(x = Timestamp, y = Value)) +
 
 <img src="man/figures/README-plot_pressure-1.png" width="80%" />
 
-Another option is to check the available variables for a given station, with the function `get_variables`. Let's consider again Overpelt (`ME11_002`) and check the first ten available variables at the Overpelt measurement station:
+Another option is to check the available variables for a given station,
+with the function `get_variables`. Let’s consider again Overpelt
+(`ME11_002`) and check the first ten available variables at the Overpelt
+measurement station:
 
 ``` r
 vars_overpelt <- get_variables("ME11_002")
@@ -145,7 +168,10 @@ head(vars_overpelt, 10)
 #> 10                WSpeed
 ```
 
-Different pre-calculated variables are already available and a `ts_id` value is available for each of them to download the corresponding data. For example, `DagGem` (= daily mean values) of `RH` (= relative humidity), i.e. `ts_id = 78382042`:
+Different pre-calculated variables are already available and a `ts_id`
+value is available for each of them to download the corresponding data.
+For example, `DagGem` (= daily mean values) of `RH` (= relative
+humidity), i.e. `ts_id = 78382042`:
 
 ``` r
 overpelt_rh_daily <- get_timeseries_tsid("78382042", 
@@ -170,18 +196,28 @@ ggplot(overpelt_rh_daily, aes(x = Timestamp, y = Value)) +
 
 <img src="man/figures/README-plot_rh-1.png" width="80%" />
 
-Unfortunately, not all variables are documented, for which the check for the appropriate variable is not (yet) fully supported by the package.
+Unfortunately, not all variables are documented, for which the check for
+the appropriate variable is not (yet) fully supported by the package.
 
-More detailed tutorials are available in the package vignettes!
+More detailed tutorials are available in the package vignettes\!
 
-Note on restrictions of the downloads
--------------------------------------
+## Note on restrictions of the downloads
 
-The amount of data downloaded from waterinfo.be is limited via a credit system. You do not need to get a token right away to download data. For limited and irregular downloads, a token will not be required.
+The amount of data downloaded from waterinfo.be is limited via a credit
+system. You do not need to get a token right away to download data. For
+limited and irregular downloads, a token will not be required.
 
-When you require more extended data requests, please request a download token from the waterinfo.be site administrators via the e-mail adress <hydrometrie@waterinfo.be> with a statement of which data and how frequently you would like to download data. You will then receive a client-credit code that can be used to obtain a token that is valid for 24 hours, after which the token can be refreshed with the same client-credit code.
+When you require more extended data requests, please request a download
+token from the waterinfo.be site administrators via the e-mail adress
+<hydrometrie@waterinfo.be> with a statement of which data and how
+frequently you would like to download data. You will then receive a
+client-credit code that can be used to obtain a token that is valid for
+24 hours, after which the token can be refreshed with the same
+client-credit code.
 
-Get token with client-credit code: (limited client-credit code for testing purposes)
+Get token with client-credit code: (limited client-credit code for
+testing
+purposes)
 
 ``` r
 client <- paste0("MzJkY2VlY2UtODI2Yy00Yjk4LTljMmQtYjE2OTc4ZjBjYTZhOjRhZGE4",
@@ -189,12 +225,12 @@ client <- paste0("MzJkY2VlY2UtODI2Yy00Yjk4LTljMmQtYjE2OTc4ZjBjYTZhOjRhZGE4",
 my_token <- get_token(client = client)
 print(my_token)
 #> Token:
-#> eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJhMDg5MDU2Ni05MWMxLTQwMjItOTk0OC1mNWFiMzcxMTgwZWQiLCJpYXQiOjE1NDQ1MTYzOTMsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9LaVdlYlBvcnRhbC9hdXRoIiwiYXVkIjoiMzJkY2VlY2UtODI2Yy00Yjk4LTljMmQtYjE2OTc4ZjBjYTZhIiwiZXhwIjoxNTQ0NjAyNzkzfQ.2ehKedVmJWSk8I10v0y5uSrOOst5NFIf3CjsWaF6vp0
+#> eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI1NjEwNTk1OS02OTRiLTQwYjEtOTdlYy04YTNhNzc0MjQ0MjUiLCJpYXQiOjE1NDQ3NDExMjEsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9LaVdlYlBvcnRhbC9hdXRoIiwiYXVkIjoiMzJkY2VlY2UtODI2Yy00Yjk4LTljMmQtYjE2OTc4ZjBjYTZhIiwiZXhwIjoxNTQ0ODI3NTIxfQ.15M1dSilAl7Ui_59wR5nWI9mQawJXZn6j_NFk_YUXYA
 #> 
 #> Attributes:
 #>  url: http://download.waterinfo.be/kiwis-auth/token
 #>  type: Bearer
-#>  expires: 2018-12-12 09:19:53 CET
+#>  expires: 2018-12-14 23:45:20 CET
 ```
 
 Receive information on the validity of the token:
@@ -208,7 +244,7 @@ Check when the token expires:
 
 ``` r
 expires.in(my_token)
-#> Time difference of 23.99999 hours
+#> Time difference of 24 hours
 ```
 
 Use token when retrieving data:
@@ -244,18 +280,25 @@ get_stations(variable_name = "verdamping_monteith", token = my_token)
 #> 8            mm          VMM
 ```
 
-Acknowledgements
-----------------
+## Acknowledgements
 
-This package is just a small wrapper around waterinfo.be to facilitate researchers and other stakeholders in downloading the data from [waterinfo.be](http://www.waterinfo.be). The availability of this data is made possible by *de Vlaamse Milieumaatschappij, Waterbouwkundig Laboratorium, Maritieme Dienstverlening & Kust, Waterwegen en Zeekanaal NV en De Scheepvaart NV*.
+This package is just a small wrapper around waterinfo.be to facilitate
+researchers and other stakeholders in downloading the data from
+[waterinfo.be](http://www.waterinfo.be). The availability of this data
+is made possible by *de Vlaamse Milieumaatschappij, Waterbouwkundig
+Laboratorium, Maritieme Dienstverlening & Kust, Waterwegen en Zeekanaal
+NV en De Scheepvaart NV*.
 
-Meta
-----
+## Meta
 
-This package is an experimental open-source project. All functionalities are provided as is, without any guarantee.
-
-Please note that this project is released with a [Contributor Code of Conduct](.github/CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
-
-Please [report any issues or bugs](https://github.com/ropensci/wateRinfo/issues/new).
+  - We welcome [contributions](.github/CONTRIBUTING.md) including bug
+    reports.
+  - License: MIT
+  - Get citation information for `wateRinfo` in R doing
+    `citation("wateRinfo")`.
+  - Please note that this project is released with a [Contributor Code
+    of Conduct](.github/CODE_OF_CONDUCT.md). By participating in this
+    project you agree to abide by its
+terms.
 
 [![ropensci\_footer](https://ropensci.org/public_images/ropensci_footer.png)](https://ropensci.org)


### PR DESCRIPTION
Update meta section in README to default section as used by bioRad, rgbif (sorry @stijnvanhoey, I like consistency 😬) 

- Fact that package is open-source is mentioned in CONTRIBUTING. Fact that it is as is without guarantee is part of MIT license. So I dropped that sentence.
- Code of conduct link remains
- Rather than direct link to bug report, link is now to CONTRIBUTING which gives more context
- License is added (but without link, because that wouldn't render in pkgdown, where it is indicated in side menu)

The differences in the knitted README.md file are caused by upgrading to Pandoc 2.5