### PR TITLE
Patch changed response

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: wateRinfo
 Title: Download Time Series Data from Waterinfo.be
-Version: 0.3.0.9058
+Version: 0.3.0.9065
 Description: wateRinfo facilitates access to waterinfo.be 
     (<https://www.waterinfo.be>), a website managed by the Flanders Environment 
     Agency (VMM) and Flanders Hydraulics Research. The website provides access 

--- a/R/call_waterinfo.R
+++ b/R/call_waterinfo.R
@@ -53,30 +53,6 @@ call_waterinfo <- function(query, base_url = "download", token = NULL) {
     }
   }
 
-  if (http_type(res) != "application/json") {
-    if (http_type(res) == "application/xml") {
-      custom_error <- content(res, "text", encoding = "UTF-8")
-      pattern <- "(?<=ExceptionText>).*(?=</ExceptionText>)"
-      error_message <- regmatches(
-        custom_error,
-        regexpr(pattern, custom_error,
-          perl = TRUE
-        )
-      )
-    } else if (http_type(res) == "text/html") {
-      custom_error <- content(res, "text", encoding = "UTF-8")
-      pattern <- paste0("(?<=Description</b>).*(?=</p><p>)|",
-                        "(?<=description</b> <u>).*(?=</u>)")
-      error_message <- regmatches(
-        custom_error,
-        regexpr(pattern, custom_error,
-                perl = TRUE
-        )
-      )
-    }
-    stop("API did not return json - ", trimws(error_message), call. = FALSE)
-  }
-
   parsed <- fromJSON(content(res, "text"))
 
   if (http_error(res)) {

--- a/tests/testthat/test-waterinfo_call.R
+++ b/tests/testthat/test-waterinfo_call.R
@@ -36,21 +36,6 @@ test_that("datasource not included in the API call", {
   )
 })
 
-tomcat_html_response <- "<!doctype html><html lang=\"en\"><head><title>HTTP Status 500 – Internal Server Error</title><style type=\"text/css\">H1 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:22px;} H2 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:16px;} H3 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:14px;} BODY {font-family:Tahoma,Arial,sans-serif;color:black;background-color:white;} B {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;} P {font-family:Tahoma,Arial,sans-serif;background:white;color:black;font-size:12px;}A {color : black;}A.name {color : black;}.line {height: 1px; background-color: #525D76; border: none;}</style></head><body><h1>HTTP Status 500 – Internal Server Error</h1><hr class=\"line\" /><p><b>Type</b> Exception Report</p><p><b>Description</b> The server encountered an unexpected condition that prevented it from fulfilling the request.</p><p><b>Exception</b></p><pre>java.lang.NullPointerException\r\n\tde.kisters.kiwis.services.kiqs.merged.MergedQueryServices.init(MergedQueryServices.java:129)\r\n\tde.kisters.kiwis.services.KistersHandler.handleKistersRequest(KistersHandler.java:148)\r\n\tde.kisters.kiwis.main.KiWIS.doKVP(KiWIS.java:1249)\r\n\tde.kisters.kiwis.main.KiWIS.doGet(KiWIS.java:583)\r\n\tjavax.servlet.http.HttpServlet.service(HttpServlet.java:622)\r\n\tjavax.servlet.http.HttpServlet.service(HttpServlet.java:729)\r\n\torg.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52)\r\n</pre><p><b>Note</b> The full stack trace of the root cause is available in the server logs.</p><hr class=\"line\" /><h3>Apache Tomcat</h3></body></html>"
-
-test_that("tomcat error message content", {
-  query <- list(
-    type = "queryServices", service = "kisters",
-    request = "getTimeseriesvalues",
-    ts_id = "notsid", format = "json"
-  )
-  base <- waterinfo_base()
-  res <- GET(base, query = query)
-  expect_identical(content(res, "text", encoding = "UTF-8"),
-                   tomcat_html_response)
-})
-
-
 test_that("add call to waterinfo explicitly to the print output", {
   skip_on_cran()
 

--- a/tests/testthat/test-waterinfo_call.R
+++ b/tests/testthat/test-waterinfo_call.R
@@ -24,17 +24,15 @@ test_that("non existing tsid to API", {
   )
 })
 
-# tackle specific case when tomcat error is thrown by the server
-# (missing datasource)
+# tackle specific case when error is thrown by the server on missing datasource
 test_that("datasource not included in the API call", {
   query <- list(
     type = "queryServices", service = "kisters",
     request = "getTimeseriesvalues",
-    ts_id = "notsid", format = "json"
+    ts_id = "5156042", format = "json"
   )
   expect_error(call_waterinfo(query),
-               regexp = paste0("API did not return json - The server ",
-                               "encountered an .*")
+               regexp = "Waterinfo API request failed.*InvalidParameterValue.*Could not find a datasource"
   )
 })
 


### PR DESCRIPTION
Fixes current build errors as described in https://github.com/ropensci/wateRinfo/issues/64. 

Previously, some API constructs were resulting in non-json responses even though requested. This improvement on the API side simplifies the code and, as such, the unit tests which where added to check these _special cases_. This PR removes the obsolete parts, without influencing any major components.