### PR TITLE
Add info on other API clients

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -137,6 +137,12 @@ Use token when retrieving data:
 get_stations(variable_name = "verdamping_monteith", token = my_token)
 ```
 
+## Other clients
+
+Besides this wateRinfo R client to gather data from [waterinfo.be](https://www.waterinfo.be/), there is also a Python client available. The [pywaterinfo](https://fluves.github.io/pywaterinfo/) package contains similar functionalities.
+
+The [Flanders Hydraulics Research center](https://www.waterbouwkundiglaboratorium.be/en/) also distributes clients for R, Python and Matlab upon request to download the data they share on [waterinfo.be](https://www.waterinfo.be/). For more information, contact them directly via [hic@vlaanderen.be](mailto:hic@vlaanderen.be).
+
 ## Acknowledgements
 
 This package is just a small wrapper around waterinfo.be to facilitate researchers and other stakeholders in downloading the data from [waterinfo.be](http://www.waterinfo.be). The availability of this data is made possible by *de Vlaamse Milieumaatschappij, Waterbouwkundig Laboratorium, Maritieme Dienstverlening & Kust, Waterwegen en Zeekanaal NV en De Scheepvaart NV*.


### PR DESCRIPTION
Small PR that adds info on other existing clients to query waterinfo data. Also refers to the hic packages that are developed internally and distributed on request.